### PR TITLE
fix: date in cmaq name

### DIFF
--- a/scripts/cmaq_demo.py
+++ b/scripts/cmaq_demo.py
@@ -89,7 +89,7 @@ date_start, date_end = "2018-07-01", "2018-07-03"
 
 point_sources.to_cmaq(wrfinput=wrfinput,
                       griddesc_path="../data/GRIDDESC",
-                      n_points=5, start_date=date_start,
+                      btrim=5, start_date=date_start,
                       end_date=date_end, week_profile=week_profile)
 
 

--- a/siem/cmaq.py
+++ b/siem/cmaq.py
@@ -197,7 +197,11 @@ def create_cmaq_file_name(cmaq_nc: xr.Dataset) -> str:
                  .isel(TSTEP=0, VAR=0)
                  .isel({"DATE-TIME": 0})
                  .values)
-    return f'cmaq_emissions_{file_date}.nc'
+    date = (dt.datetime
+            .strptime(str(file_date), "%Y%j")
+            .date()
+            .strftime("%Y%m%d"))
+    return f'cmaq_emissions_{date}.nc'
 
 
 def save_cmaq_file(cmaq_nc: xr.Dataset,

--- a/tests/test_create_cmaq_file_name.py
+++ b/tests/test_create_cmaq_file_name.py
@@ -43,4 +43,4 @@ def test_create_cmaq_file_name() -> None:
 
     os.remove("GRIDDESC")
 
-    assert file_name == "cmaq_emissions_2018182.nc"
+    assert file_name == "cmaq_emissions_20180701.nc"


### PR DESCRIPTION
Using YYYYMMDD format in emission file to easier config in CCTM.