### PR TITLE
fix: error in some cmaq species units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info
 __pycache__
+.pytest_cache
 data/wrfinput_*
 data/partial/*
 data/geo_em*

--- a/siem/cmaq.py
+++ b/siem/cmaq.py
@@ -307,6 +307,8 @@ def add_cmaq_emission_attrs(speciated_cmaq: xr.Dataset,
         speciated_cmaq[pol].attrs["units"] = "moles/s"
         if (pol == pm_name) or (pol in pm_species.keys()):
             speciated_cmaq[pol].attrs["units"] = "g/s"
+        if (pol in ["IOLE", "VOC_INV", "NVOL"]):
+            speciated_cmaq[pol].attrs["units"] = "g/s"
         speciated_cmaq[pol].attrs["long_name"] = f"{pol:<16}"
         speciated_cmaq[pol].attrs["var_desc"] = f"{var_desc:<80}"
 

--- a/tests/test_add_cmaq_emission_attrs.py
+++ b/tests/test_add_cmaq_emission_attrs.py
@@ -9,7 +9,8 @@ def test_add_cmaq_emission_attrs() -> None:
     spatial_proxy = read_spatial_proxy("./data/ldv_s3.txt",
                                        (24, 14),
                                        ["id", "x", "y", "a", "b", "urban"])
-    voc_species = {"HC3": 0.5, "HC5": 0.25, "HC8": 0.25}
+    voc_species = {"HC3": 0.5, "HC5": 0.25, "HC8": 0.25,
+                   "VOC_INV": 1, "NVOL": 1, "IOLE": 1}
     pm_species = {"PM10": 0.3, "PM25_I": 0.7 * 0.5, "PM25_J": 0.7 * 0.5}
 
     test_source = EmissionSource("test source",
@@ -34,5 +35,8 @@ def test_add_cmaq_emission_attrs() -> None:
     assert "VOC" not in speciated_attrs.data_vars
     assert speciated_attrs.NOX.units == "moles/s"
     assert speciated_attrs.PM10.units == "g/s"
+    assert speciated_attrs.VOC_INV.units == "g/s"
+    assert speciated_attrs.NVOL.units == "g/s"
+    assert speciated_attrs.IOLE.units == "g/s"
     assert len(speciated_attrs.PM10.var_desc) == 80
     assert len(speciated_attrs.PM10.long_name) == 16


### PR DESCRIPTION
This solves @adelgadop question about VOC_INV, NVOL, and IOLE units error when using siem output in smoke merge.