### PR TITLE
feat: wrfchemi in different netCDF file formats

### DIFF
--- a/siem/siem.py
+++ b/siem/siem.py
@@ -276,6 +276,7 @@ class EmissionSource:
                     week_profile: list[float] = [1],
                     pm_name: str = "PM", voc_name: str = "VOC",
                     write_netcdf: bool = False,
+                    nc_format: str = 'NETCDF3_64BIT',
                     path: str = "../results") -> xr.Dataset:
         """
         Create WRF-Chem emission file (wrfchemi).
@@ -296,6 +297,8 @@ class EmissionSource:
             VOC name in pol_ef keys
         write_netcdf : bool
             Write the NetCDF file.
+        nc_format : str
+            wrfchemi netCDF file format.
         path : str
             Location to save wrfchemi.
 
@@ -325,7 +328,7 @@ class EmissionSource:
                                                        start_date)
 
         if write_netcdf:
-            wemi.write_wrfchemi_netcdf(wrfchemi_netcdf, path)
+            wemi.write_wrfchemi_netcdf(wrfchemi_netcdf, nc_format, path)
         return wrfchemi_netcdf
 
     def to_cmaq(self, wrfinput: xr.Dataset, griddesc_path: str,
@@ -508,6 +511,7 @@ class PointSources:
                     week_profile: list[float] = [1],
                     pm_name: str = "PM", voc_name: str = "VOC",
                     write_netcdf: bool = False,
+                    nc_format: str = 'NETCDF3_64BIT',
                     path: str = "../results/"
                     ) -> xr.Dataset:
         """
@@ -529,6 +533,8 @@ class PointSources:
             VOC name in pol_emiss.
         write_netcdf : bool
             Write wrfchemi netCDF.
+        nc_format : str
+            wrfchemi netCDF file format.
         path : str
             Location to save wrfchemi files.
 
@@ -555,7 +561,7 @@ class PointSources:
         wrfchemi_netcdf = wemi.prepare_wrfchemi_netcdf(point_speciated,
                                                        wrfinput, start_date)
         if write_netcdf:
-            wemi.write_wrfchemi_netcdf(wrfchemi_netcdf, path)
+            wemi.write_wrfchemi_netcdf(wrfchemi_netcdf, nc_format, path)
         return wrfchemi_netcdf
 
     def to_cmaq(self, wrfinput: xr.Dataset, griddesc_path: str,
@@ -696,6 +702,7 @@ class GroupSources:
                     week_profile: list[float] = [1],
                     pm_name: str = "PM", voc_name: str = "VOC",
                     write_netcdf: bool = False,
+                    nc_format: str = 'NETCDF3_64BIT',
                     path: str = "../results") -> xr.Dataset:
         """
         Create WRF-Chem emission file.
@@ -716,6 +723,8 @@ class GroupSources:
             VOC name in emissions.
         write_netcdf : bool
             Save wrfchemi file.
+        nc_format : str
+            wrfchemi netCDF file format.
         path : str
             Location to save wrfchemi file.
 
@@ -739,7 +748,7 @@ class GroupSources:
                 dims=["Time"],
                 coords={"Time": wrfchemi.Time.values}
             )
-            wemi.write_wrfchemi_netcdf(wrfchemi, path=path)
+            wemi.write_wrfchemi_netcdf(wrfchemi, nc_format, path=path)
         return wrfchemi
 
     def to_cmaq(self, wrfinput: xr.Dataset, griddesc_path: str,

--- a/siem/wrfchemi.py
+++ b/siem/wrfchemi.py
@@ -12,7 +12,7 @@ It contains the following functions:
     - `create_date_s19(start_date, periods)` - Returns date in s19 type.
     - `prepare_wrfchemi_netcdf(speciated_wrfchemi, wrfinput)` - Returns a xr.Dataset with wrfchemi format (attributes). 
     - `create_wrfchemi_name(wrfchemi)` - Return file name based on the number of periods.
-    - `write_netcdf(wrfchemi_netcdf, file_name, path)` - Write wrfchemi file on disk in NETCDF3_64BIT.
+    - `write_netcdf(wrfchemi_netcdf, file_name, path)` - Write wrfchemi file on disk.
     - `write_wrfchemi_netcdf(wrfchemi_netcdf, path)` - Write wrfchemi file on disk based on Times variable.
 
 """
@@ -288,7 +288,7 @@ def create_wrfchemi_name(wrfchemi: xr.Dataset) -> str | tuple:
 
 
 def write_netcdf(wrfchemi_netcdf: xr.Dataset, file_name: str,
-                 path: str = "../results/") -> None:
+                 nc_format: str, path: str = "../results/") -> None:
     """
     Save netcdf file.
 
@@ -298,6 +298,8 @@ def write_netcdf(wrfchemi_netcdf: xr.Dataset, file_name: str,
         wrfchemi dataset in WRF-Chem wrfchemi netcdf format.
     file_name : str
         wrfchemi file names.
+    nc_format : str
+        wrfchemi netCDF file format.
     path : str
         Path to save  netcdf.
 
@@ -308,10 +310,11 @@ def write_netcdf(wrfchemi_netcdf: xr.Dataset, file_name: str,
                                   "Times": {"char_dim_name": "DateStrLen"}
                               },
                               unlimited_dims={"Time": True},
-                              format="NETCDF3_64BIT")
+                              format=nc_format)
 
 
 def write_wrfchemi_netcdf(wrfchemi_netcdf: xr.Dataset,
+                          nc_format: str,
                           path: str) -> None:
     """
     Save the wrfchemi in WRF-Chem netcdf format in netcdf file.
@@ -320,6 +323,8 @@ def write_wrfchemi_netcdf(wrfchemi_netcdf: xr.Dataset,
     ----------
     wrfchemi_netcdf : xr.Dataset
         wrfchemi dataset in WRF-Chem wrfchemi netcdf format.
+    nc_format : str
+        wrfchemi netCDF file format.
     path : str
         Location to save the wrfchemi file.
 
@@ -328,9 +333,10 @@ def write_wrfchemi_netcdf(wrfchemi_netcdf: xr.Dataset,
         file_names = create_wrfchemi_name(wrfchemi_netcdf)
         wrfchemi00z = wrfchemi_netcdf.isel(Time=slice(0, 12))
         wrfchemi12z = wrfchemi_netcdf.isel(Time=slice(12, 24))
-        write_netcdf(wrfchemi00z, file_names[0], path)
-        write_netcdf(wrfchemi12z, file_names[1], path)
+        write_netcdf(wrfchemi00z, file_names[0], nc_format, path)
+        write_netcdf(wrfchemi12z, file_names[1], nc_format, path)
     else:
         write_netcdf(wrfchemi_netcdf,
                      create_wrfchemi_name(wrfchemi_netcdf),
+                     nc_format,
                      path)


### PR DESCRIPTION
- `nc_format` argument added in `.to_wrfchemi` method to define the emission netCDF file format. Depending on netCDF compilation and WRF-Chem installation (e.g. with netCDF4 enabled), it could be required a different netCDF format.