### PR TITLE
refrac: no more dependency on wrf-python

### DIFF
--- a/siem/point.py
+++ b/siem/point.py
@@ -18,7 +18,7 @@ import geopandas as gpd
 import xarray as xr
 from netCDF4 import Dataset
 from siem.proxy import create_wrf_grid, configure_grid_spatial
-from wrf import getvar, get_cartopy
+import pyproj
 
 
 def create_gpd_from(
@@ -97,9 +97,29 @@ def retrive_proj_from(geogrid_path: str):
     Returns:
         Projection of geo_em.d0x.nc
     """
-    with Dataset(geogrid_path) as geo_dom:
-        hgt = getvar(geo_dom, "HGT_M")
-    return get_cartopy(hgt)
+    geo_ds = xr.open_dataset(geogrid_path)
+    a = 6370000.0
+    b = 6370000.0
+
+    lcc = pyproj.Proj(proj='lcc', lat_1=geo_ds.TRUELAT1, lat_2=geo_ds.TRUELAT2, 
+                      lat_0=geo_ds.MOAD_CEN_LAT, lon_0=geo_ds.STAND_LON, 
+                      a=a, b=b)
+    merc = pyproj.Proj(proj='merc', lon_0=geo_ds.STAND_LON, lat_ts=geo_ds.TRUELAT1,
+                       a=a, b=b)
+    stere = pyproj.Proj(proj='stere', lat_0=geo_ds.TRUELAT1, lon_0=geo_ds.STAND_LON,
+                        lat_ts=geo_ds.TRUELAT1, a=a, b=b)
+    latlon = pyproj.Proj(proj='longlat', lon_0=geo_ds.STAND_LON, a=a, b=b)
+
+    proj_codes = {
+        1: lcc, # lambert
+        2: stere, # polar
+        3: merc, # merc 
+        6: latlon # latlon
+    }
+    
+    wrf_proj = proj_codes[geo_ds.MAP_PROJ]
+    wrf_crs = pyproj.CRS.from_proj4(str(wrf_proj))
+    return wrf_crs
 
 
 def calculate_centroid(emiss_point: gpd.GeoDataFrame, geo_path: str) -> pd.DataFrame:

--- a/tests/test_retrieve_proj_from_geo.py
+++ b/tests/test_retrieve_proj_from_geo.py
@@ -1,9 +1,9 @@
 from siem.point import retrive_proj_from
-import cartopy.crs as ccrs
+import pyproj
 
 def test_retrieve_proj_from() -> None:
     geo_path = "./tests/test_data/geo_em.d01.siem_test.nc"
 
     wrf_proj = retrive_proj_from(geo_path)
 
-    assert isinstance(wrf_proj, ccrs.Projection)
+    assert isinstance(wrf_proj, pyproj.crs.crs.CRS)


### PR DESCRIPTION
This PR avoids the dependence  on wry-python. WRF domain projection is retrieve using pyproj.